### PR TITLE
Fix for SpatialAnchorsUnity : GetLoggedInUserCallback error on editor…

### DIFF
--- a/Assets/SharedSpatialAnchors/Scripts/PhotonAnchorManager.cs
+++ b/Assets/SharedSpatialAnchors/Scripts/PhotonAnchorManager.cs
@@ -1,4 +1,5 @@
-﻿/*
+﻿using System.Collections;
+/*
 * Copyright (c) Meta Platforms, Inc. and affiliates.
 * All rights reserved.
 *
@@ -75,13 +76,26 @@ public class PhotonAnchorManager : PhotonPun.MonoBehaviourPunCallbacks
         }
     }
 
-    private void Start()
+    private IEnumerator Start()
     {
         SampleController.Instance.Log("System version: " + OVRPlugin.version);
-
         PhotonPun.PhotonNetwork.ConnectUsingSettings();
-
         Core.Initialize();
+        
+        while(Core.IsInitialized())
+        yield return null;
+
+        Oculus.Platform.Entitlements.IsUserEntitledToApplication().OnComplete(OnEntitlementCallback);
+    }
+
+    void OnEntitlementCallback(Message msg)
+    {
+        if(msg.IsError)
+        {
+            SampleController.Instance.Log("Entitlement Failed: failed with error: " + msg.GetError());
+            return;
+        }
+        
         Users.GetLoggedInUser().OnComplete(GetLoggedInUserCallback);
 
         Array.Resize(ref _fakePacket, 1 + UuidSize);


### PR DESCRIPTION
Fix for error occuring in Editor play mode through Oculus link:
SpatialAnchorsUnity: GetLoggedInUserCallback: failed with error: Oculus.Platform.Models.Error
UnityEngine.Debug:Log (object)
SampleController:Log (string) (at Assets/SharedSpatialAnchors/Scripts/SampleController.cs:131)
PhotonAnchorManager:GetLoggedInUserCallback (Oculus.Platform.Message) (at Assets/SharedSpatialAnchors/Scripts/PhotonAnchorManager.cs:129)

Added code to wait until platform is initialized and entitlement to application is checked